### PR TITLE
ci(deploy): fallback origin + gated Worker step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
       - name: Install wrangler
@@ -27,6 +27,11 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           set -euo pipefail
+          if [[ -z "${CLOUDFLARE_API_TOKEN:-}" || -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
+            echo "Cloudflare secrets missing; skipping Worker deploy."
+            echo "origin=${{ secrets.REACT_APP_API_ORIGIN }}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           # Write a minimal wrangler.toml using provided D1 id/name if available
           if [[ -n "${{ secrets.D1_DB_NAME }}" && -n "${{ secrets.D1_DB_ID }}" ]]; then
             cat > backend/wrangler.toml <<EOF
@@ -49,8 +54,10 @@ jobs:
         working-directory: frontend
         env:
           REACT_APP_API_ORIGIN: ${{ steps.worker.outputs.origin }}
+          FALLBACK_ORIGIN: ${{ secrets.REACT_APP_API_ORIGIN }}
         run: |
           npm ci
+          export REACT_APP_API_ORIGIN="${REACT_APP_API_ORIGIN:-$FALLBACK_ORIGIN}"
           npm run build
       - name: Deploy Pages
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,18 +20,17 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
       - name: Install wrangler
         run: npm i -g wrangler@4
+      - name: Resolve frontend origin (fallback)
+        id: origin
+        run: echo "origin=${{ secrets.REACT_APP_API_ORIGIN }}" >> "$GITHUB_OUTPUT"
       - name: Deploy Worker and capture origin
         id: worker
+        if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           set -euo pipefail
-          if [[ -z "${CLOUDFLARE_API_TOKEN:-}" || -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
-            echo "Cloudflare secrets missing; skipping Worker deploy."
-            echo "origin=${{ secrets.REACT_APP_API_ORIGIN }}" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
           # Write a minimal wrangler.toml using provided D1 id/name if available
           if [[ -n "${{ secrets.D1_DB_NAME }}" && -n "${{ secrets.D1_DB_ID }}" ]]; then
             cat > backend/wrangler.toml <<EOF
@@ -53,11 +52,9 @@ jobs:
       - name: Build frontend
         working-directory: frontend
         env:
-          REACT_APP_API_ORIGIN: ${{ steps.worker.outputs.origin }}
-          FALLBACK_ORIGIN: ${{ secrets.REACT_APP_API_ORIGIN }}
+          REACT_APP_API_ORIGIN: ${{ steps.worker.outputs.origin || steps.origin.outputs.origin }}
         run: |
           npm ci
-          export REACT_APP_API_ORIGIN="${REACT_APP_API_ORIGIN:-$FALLBACK_ORIGIN}"
           npm run build
       - name: Deploy Pages
         env:


### PR DESCRIPTION
Skip Worker deploy when CF secrets are missing using an if-condition and feed REACT_APP_API_ORIGIN from a fallback step output. Node 20 is already configured for Wrangler.